### PR TITLE
Fixed bug that returns 1, instead of 0 in distance

### DIFF
--- a/lib/src/FaceRecognizer/commons.js
+++ b/lib/src/FaceRecognizer/commons.js
@@ -50,7 +50,7 @@ function makeComputeMeanDistance(fr) {
       descriptors
         .map(d => fr.distance(d, inputDescriptor))
         .reduce((d1, d2) => d1 + d2, 0)
-          / descriptors.length || 1
+          / (descriptors.length || 1)
       )
   }
 }


### PR DESCRIPTION
This only happened when a class only had a single face added to it.