### PR TITLE
Throw error when jitter is required & nr of cols and rows is not same

### DIFF
--- a/lib/src/FaceRecognizer/commons.js
+++ b/lib/src/FaceRecognizer/commons.js
@@ -60,6 +60,9 @@ function makeComputeMeanDistance(fr) {
 /* but also training time increases with numJitters  */
 function makeGetJitteredFaces(fr) {
   return function(face, numJitters) {
+    if (numJitters && (face.rows !== face.cols)) {
+      throw new Error('jittering requires the face to have the same number of rows and cols')
+    }
     return [face].concat(!numJitters ? [] : fr.jitterImage(face, numJitters))
   }
 }


### PR DESCRIPTION
This check will not let the process crash and provides an opportunity for the app to catch and arrest it.

dlib::jitter crashes if an image where rows != cols are supplied.